### PR TITLE
ravello-set-rtc: new utility to set the RTC

### DIFF
--- a/tools/ravello-set-rtc
+++ b/tools/ravello-set-rtc
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+#
+# Script to enable an image or VM for nested virtualization.
+#
+# Copyright (c) 2014 Ravello Systems Inc. Released under Apache 2 license.
+
+"""Set the real-time clock for one or all VMs in an application.
+
+Usage:
+  ravello-set-rtc [options] (--absolute <seconds> | --relative <seconds>)
+                  <application> [<vm>]
+  ravello-set-rtc (-h | --help)
+
+The <application> argument specifies the application to update. If the optional
+<vm> argument is specified, just that VM is updated. Otherwise all VMs are
+updated.  Both arguments are interpreted as names first, and if no such object
+is found, as IDs.
+
+If the application was published, the updates are published as well.
+
+Arguments:
+  <application>     The application name or ID.
+  <vm>              The VM name or ID.
+
+Options:
+  -u <username>, --username=<username>
+                    Ravello API username. If absent use $RAVELLO_USERNAME.
+  -p <password>, --password=<password>
+                    Ravello API password. If absent use $RAVELLO_PASSWORD.
+  --absolute <seconds>
+                    Set the RTC to this absolute date. The date is a Unix
+                    timestamp i.e. number of seconds since Jan 1st 1970.
+  --relative <seconds>
+                    Set the RTC to this relative value. The value is the number
+                    of seconds relative to the current time. A positive value
+                    indicates a time in the future.
+  -d, --debug       Enable debugging mode.
+"""
+
+import os
+import sys
+
+import logging
+from docopt import docopt
+from getpass import getpass
+from ravello_sdk import RavelloClient
+from ravello_cli import get_application
+
+
+def parse_args():
+    """Parse and validate arguments."""
+    args = docopt(__doc__)
+    if not args['--username']:
+        args['--username'] = os.environ.get('RAVELLO_USERNAME')
+    if not args['--username']:
+        raise ValueError('specify --username or set $RAVELLO_USERNAME')
+    if not args['--password']:
+        args['--password'] = os.environ.get('RAVELLO_PASSWORD')
+    if not args['--password'] and sys.stdin.isatty():
+        args['--password'] = getpass('Enter Ravello API password: ')
+    if not args['--password']:
+        raise ValueError('specify --password or set $RAVELLO_PASSWORD')
+    return args
+
+
+def resolve_args(client, args):
+    """Resolve referenced objects in the arguments."""
+    values = args.copy()
+    app = get_application(client, args['<application>'])
+    if not app:
+        raise ValueError('no such application: {0}'.format(args['<application>']))
+    values['application'] = app
+    if args['<vm>']:
+        for vm in app['design'].get('vms'):
+            if vm['id'] == args['<vm>'] or vm['name'] == args['<vm>']:
+                values['vm'] = vm
+                break
+        else:
+            raise ValueError('no such vm: {0}'.format(args['<vm>']))
+    else:
+        values['vm'] = None
+    return values
+
+
+def main():
+    """Main entry point."""
+    debug = True
+    try:
+        args = parse_args()
+        debug = args['--debug']
+        logging.basicConfig(level=logging.DEBUG if debug else logging.INFO)
+
+        client = RavelloClient(args['--username'], args['--password'])
+
+        args = resolve_args(client, args)
+
+        if args.get('--absolute'):
+            rtc = {'mode': 'ABSOLUTE', 'seconds': int(args['--absolute'])}
+        else:
+            rtc = {'mode': 'RELATIVE', 'seconds': int(args['--relative'])}
+
+        app = args['application']
+        if args['vm']:
+            args['vm']['rtc'] = rtc
+        else:
+            for vm in app['design'].get('vms'):
+                vm['rtc'] = rtc
+
+        app = client.update_application(app)
+        # Need to update twice to get rid of a design error that I do not understand.
+        app = client.update_application(app)
+
+        if app['published']:
+            client.publish_application_updates(app['id'])
+            print('Real-time clock updated, and application republished.')
+        else:
+            print('Real-time clock updated.')
+
+    except Exception as e:
+        if debug:
+            raise
+        sys.stderr.write('Error: {0!s}\n'.format(e))
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add a new utility that allows you to set the system clock of the VMs in an application. Both unpublished and published applications are supported.