### PR TITLE
add create_diskimage() using undocumented POST /diskImages

### DIFF
--- a/lib/ravello_sdk.py
+++ b/lib/ravello_sdk.py
@@ -688,6 +688,15 @@ class RavelloClient(object):
             imgs = _match_filter(imgs, filter)
         return imgs
 
+    def create_diskimage(self, img):
+        """Create a new disk image.
+
+        The *img* parameter must be a dict describing the disk image to create.
+
+        The new disk image is returned.
+        """
+        return self.request('POST', '/diskImages', img)
+
     def update_diskimage(self, img):
         """Update an existing image.
 


### PR DESCRIPTION
Not sure why this is undocumented ... but it works and I'm using it in my project.

Example that you can use practically verbatim:
```
import ravello_sdk, json
R = ravello_sdk.RavelloClient()
R.login(USER, PASS)
appId = R.get_applications()[0]['id']
app = R.get_application(appId)
vm = app['design']['vms'][0]
hdd0 = vm['hardDrives'][0]
newName = "snapshot-{}/{}/{}".format(app['name'], vm['name'], hdd0['name'])
img = {'applicationId': appId,
       'vmId': vm['id'],
       'diskId': hdd0['id'],
       'offline': True,
       'diskImage': {'name': newName}}
newImg = R.create_diskimage(img)
print(newImg)
print(json.dumps(newImg, indent=4))
```

The output of that very last command for me was:

```
{
    "name": "snapshot-k:rsawhill__test123/rhel7-base/rhel7-base", 
    "isPublic": false, 
    "creationTime": 1420760833126, 
    "loadingStatus": "DONE", 
    "_href": "/diskImages/53837847", 
    "loadingPercentage": 100, 
    "owner": "Ryan Sawhill", 
    "id": 53837847, 
    "size": {
        "unit": "GB", 
        "value": 8
    }
}
```