### PR TITLE
Create verification for headers parameter in _request; check if it is a dict or list

### DIFF
--- a/lib/ravello_sdk.py
+++ b/lib/ravello_sdk.py
@@ -354,8 +354,12 @@ class RavelloClient(object):
             hdict['X-Ephemeral-Token-Authorization'] = self._eph_token
         if body:
             hdict['Content-Type'] = 'application/json'
-        for key, value in headers:
-            hdict[key] = value
+        if isinstance(headers, dict):
+            for key, value in headers.items():
+                hdict[key] = value
+        elif isinstance(headers, list):
+            for key, value in headers:
+                hdict[key] = value
         retries = 0
         while retries < self.retries:
             if not self.logged_in and (self.have_credentials or self.have_eph_access_token) and self._autologin:

--- a/lib/ravello_sdk.py
+++ b/lib/ravello_sdk.py
@@ -355,8 +355,7 @@ class RavelloClient(object):
         if body:
             hdict['Content-Type'] = 'application/json'
         if isinstance(headers, dict):
-            for key, value in headers.items():
-                hdict[key] = value
+            hdict.update(headers)
         elif isinstance(headers, list):
             for key, value in headers:
                 hdict[key] = value


### PR DESCRIPTION
When calling request() with headers parameter, issue this error:

```python
>>> rav.request('POST', '/applications/' + app_id + '/publish', headers = {'Accept': 'application/json'})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jonatas/py_env/ravsys/lib/python3.4/site-packages/ravello_sdk.py", line 346, in request
    response = self._request(method, path, body, headers)
  File "/home/jonatas/py_env/ravsys/lib/python3.4/site-packages/ravello_sdk.py", line 357, in _request
    for key, value in headers:
ValueError: too many values to unpack (expected 2)
```

I had to check if the headers is dict OR list because in line 310 (and maybe other places), the _login method uses it as list:
```python
headers = [('Authorization', 'Basic {0}'.format(auth))]
```

Thanks!