### PR TITLE
Add invite_user(user) call

### DIFF
--- a/lib/ravello_sdk.py
+++ b/lib/ravello_sdk.py
@@ -962,6 +962,15 @@ class RavelloClient(object):
         org = self.get_organization()['id']
         return self.request('POST', '/organizations/{0}/users'.format(org), user)
 
+    def invite_user(self, user):
+        """Invite a new user.
+
+        The *user* parameter must be a dict describing the user to invite.
+
+        The new user is returned.
+        """
+        return self.request('POST', '/users/invite', user)
+
     def update_user(self, user, userId):
         """Update an existing user.
 


### PR DESCRIPTION
Although __doc__ of preceding create_user() call made it sound like it
would invite a user, feeding it a parameter dict as discussed in Ravello
API docs returns a HTTP 500, and the URL seems misaligned from the
API docs. invite_user() has the intended behavior, without trying to
address apparent shortcomings of create_user().