### PR TITLE
In get_vnc_url(), only use url.decode if needed (PY2?)

### DIFF
--- a/lib/ravello_sdk.py
+++ b/lib/ravello_sdk.py
@@ -707,7 +707,9 @@ class RavelloClient(object):
         headers = [('Accept', 'text/plain')]
         url = self.request('GET', '/applications/{0}/vms/{1}/vncUrl'.format(app, vm),
                            headers=headers)
-        return url.decode('iso-8859-1')
+        if hasattr(url, "decode"):
+            return url.decode('iso-8859-1')
+        return url
 
     def get_detailed_charges_for_application(self, app, mode = 'deployment', deployment_options = {}):
         """Get the detailed hourly charges for an application.


### PR DESCRIPTION
   - definitely breaks under py3.6.2+requests==2.18.3.  I *think* it is
     a PY3 issue, but have not tested extensively.  Originally, my
     conditional was "if pyver[0] == 2", but thought I should generalize.