### PR TITLE
Fixed formatting errors in some of the examples, which were encoding …

### DIFF
--- a/examples/app-get-all
+++ b/examples/app-get-all
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# A Ravello SDK example showing all applications in a user account in format: 
+# A Ravello SDK example showing all applications in a user account in format:
 # Application name, ID, Creation Time, Owner, If published, Region
 #
 # Copyright 2011-2016 Ravello Systems, Inc.
@@ -34,11 +34,11 @@ def print_apps(apps):
 	for app in apps:
 		creation_time = datetime.datetime.fromtimestamp(app['creationTime']/1000).strftime('%Y-%m-%d %H:%M')
 		if app['published']:
-			print('Application name: {0:<50} ID: {1:<10} Creation Date: {2:<20} Owner: {3:<25} Published: yes    Region: {4:<10}'.format(app['name'].encode('utf-8'),app['id'],creation_time,app['ownerDetails']['name'],app['deployment']['cloudRegion']['name']))
+			print('Application name: {0:<50} ID: {1:<10} Creation Date: {2:<20} Owner: {3:<25} Published: yes    Region: {4:<10}'.format(app['name'],app['id'],creation_time,app['ownerDetails']['name'],app['deployment']['cloudRegion']['name']))
 		else:
-			print('Application name: {0:<50} ID: {1:<10} Creation Date: {2:<20} Owner: {3:<25} Published: no'.format(app['name'].encode('utf-8'),app['id'],creation_time,app['ownerDetails']['name'],app['published']))
-		
-		
+			print('Application name: {0:<50} ID: {1:<10} Creation Date: {2:<20} Owner: {3:<25} Published: no'.format(app['name'],app['id'],creation_time,app['ownerDetails']['name'],app['published']))
+
+
 def main():
 	parser = mkparser()
 	args = parser.parse_args()

--- a/examples/app-get-billing
+++ b/examples/app-get-billing
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# A Ravello SDK example showing list of all applications and their cost in a specific month/year   
+# A Ravello SDK example showing list of all applications and their cost in a specific month/year
 #
 # Copyright 2011-2016 Ravello Systems, Inc.
 #
@@ -39,7 +39,7 @@ def set_billing_period(args):
 
 	if not month:
 		month = now.month
- 
+
 	if not year:
 		year = now.year
 
@@ -51,8 +51,8 @@ def print_billing_info(bi):
 		for charge in app['charges']:
 			price += charge['summaryPrice']
 
-		print('Application name: {0:<50} Owner: {1:<25} Price: {2:8.2f}'.format(app['appName'].encode('utf-8'),app['owner'],price))
-		
+		print('Application name: {0:<50} Owner: {1:<25} Price: {2:8.2f}'.format(app['appName'],app['owner'],price))
+
 def main():
 	parser = mkparser()
 	args = parser.parse_args()
@@ -72,7 +72,7 @@ def main():
 	#Get List of applications with billing info
 	bi = client.get_billing_for_month(year,month)
 
-		
+
 	#Display billing info
 	print_billing_info(bi)
 

--- a/examples/app-get-vms
+++ b/examples/app-get-vms
@@ -43,7 +43,7 @@ def get_vms(app_id, client):
 def print_vms(vms,out_file):
 	if vms:
 		for vm in vms:
-			print('Name: {0:<40} ID: {1:<20} State: {2}'.format(vm['name'].encode('utf-8'),vm['id'], vm['state']))
+			print('Name: {0:<40} ID: {1:<20} State: {2}'.format(vm['name'],vm['id'], vm['state']))
 
 #		print (json.dumps(vms, indent=5))
 

--- a/examples/bp-get-all
+++ b/examples/bp-get-all
@@ -15,10 +15,10 @@ def print_bps(bps):
 	for bp in bps:
 		creation_time = datetime.datetime.fromtimestamp(bp['creationTime']/1000).strftime('%Y-%m-%d %H:%M')
 		description = bp.get('description')
-		if not description: 	
+		if not description:
 			description = ''
-		print('Blueprint name: {0:<50} ID: {1:<10} Created: {2:<20} Owner: {3:<25} Description: {4:>30}'.format(bp['name'].encode('utf-8'),bp['id'],creation_time,bp['ownerDetails']['name'],description.encode('utf-8')))
-		
+		print('Blueprint name: {0:<50} ID: {1:<10} Created: {2:<20} Owner: {3:<25} Description: {4:>30}'.format(bp['name'],bp['id'],creation_time,bp['ownerDetails']['name'],description))
+
 def main():
 	parser = mkparser()
 	args = parser.parse_args()


### PR DESCRIPTION
…to utf-8 inside a format() function.

Some of the examples had print function like this one:

```
print('Name: {0:<40} ID: {1:<20} State: {2}'.format(vm['name'].encode('utf-8'),vm['id'], vm['state']))
```

This results in the following error: *Error: non-empty format string passed to object.\__format\__*.
Removing the `.encode('utf-8')` part fixes the problem.

Or is there a specific use case for the encoding and I'm missing something here?